### PR TITLE
[minoir] Fix repeat group parent_id definition...

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -8324,6 +8324,9 @@ class FabrikFEModelList extends JModelForm
 		$item->name = $item->label = 'parent_id';
 		$item->hidden = 1;
 		$item->group_id = $groupId;
+		$item->text_format = "integer";
+		$item->integer_length = 11;
+		$item->decimal_length = 0;
 
 		if (!$item->store())
 		{


### PR DESCRIPTION
... so that Fabrik does not try to convert database column to TEXT on first admin save of element settings.

Note: Not tested.